### PR TITLE
modify readme.md : notice the version of react

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Setup
     npm install -g browserify watchify http-server
     ```
 
+    Notice: The version of react is 0.12.2 in this repo. If your local version is ^0.14, some usecase may be different in js file. 
+
 [Next](#newsitem)
 
 ---


### PR DESCRIPTION
As we know, the latest version of react is [0.14.3](https://facebook.github.io/react/downloads.html). And you need use react.js and react-dom.js to develop your app. "React.render" is also needs to be replaced by "ReactDOM.render".

I have also created a repo with a  upgraded the version of th react based on this repo.[See more](https://github.com/reygreen1/react-hacknews).
